### PR TITLE
M1: Retrieval v1 — top-k similarity search with filters and trace

### DIFF
--- a/src/ragcopilot/retrieval/__init__.py
+++ b/src/ragcopilot/retrieval/__init__.py
@@ -5,6 +5,9 @@ from .models import (
     RetrievalTrace,
     RetrievalResult,
 )
+from .interfaces import EmbeddingProvider, VectorIndex, Retriever
+from .index import InMemoryCosineVectorIndex
+from .retrievers import BasicRetriever
 
 __all__ = [
     "RetrievalFilter",
@@ -12,4 +15,9 @@ __all__ = [
     "RetrievedChunk",
     "RetrievalTrace",
     "RetrievalResult",
+    "EmbeddingProvider",
+    "VectorIndex",
+    "Retriever",
+    "InMemoryCosineVectorIndex",
+    "BasicRetriever",
 ]

--- a/src/ragcopilot/retrieval/__init__.py
+++ b/src/ragcopilot/retrieval/__init__.py
@@ -1,0 +1,15 @@
+from .models import (
+    RetrievalFilter,
+    RetrievalQuery,
+    RetrievedChunk,
+    RetrievalTrace,
+    RetrievalResult,
+)
+
+__all__ = [
+    "RetrievalFilter",
+    "RetrievalQuery",
+    "RetrievedChunk",
+    "RetrievalTrace",
+    "RetrievalResult",
+]

--- a/src/ragcopilot/retrieval/index/__init__.py
+++ b/src/ragcopilot/retrieval/index/__init__.py
@@ -1,0 +1,3 @@
+from .in_memory import InMemoryCosineVectorIndex
+
+__all__ = ["InMemoryCosineVectorIndex"]

--- a/src/ragcopilot/retrieval/index/in_memory.py
+++ b/src/ragcopilot/retrieval/index/in_memory.py
@@ -1,0 +1,110 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from math import sqrt
+from typing import Any, Dict, Iterable, List, Mapping, Sequence, Tuple
+
+from ..models import RetrievedChunk, RetrievalFilter
+from ..interfaces import VectorIndex
+
+
+def _as_tuple(vec: Sequence[float]) -> Tuple[float, ...]:
+    return tuple(float(x) for x in vec)
+
+
+def _dot(a: Tuple[float, ...], b: Tuple[float, ...]) -> float:
+    return sum(x * y for x, y in zip(a, b))
+
+
+def _norm(a: Tuple[float, ...]) -> float:
+    return sqrt(_dot(a, a))
+
+
+def cosine_similarity(a: Sequence[float], b: Sequence[float]) -> float:
+    """
+    Deterministic cosine similarity.
+    Returns 0.0 if any vector is zero-norm.
+    """
+    at = _as_tuple(a)
+    bt = _as_tuple(b)
+    if len(at) != len(bt):
+        raise ValueError("Vectors must have the same dimensionality.")
+
+    na = _norm(at)
+    nb = _norm(bt)
+    if na == 0.0 or nb == 0.0:
+        return 0.0
+
+    return _dot(at, bt) / (na * nb)
+
+
+def _chunk_id(chunk: Any) -> str:
+    cid = getattr(chunk, "chunk_id", None)
+    if cid is None:
+        raise AttributeError("Chunk object must have attribute 'chunk_id'.")
+    return str(cid)
+
+
+def _chunk_meta(chunk: Any) -> Mapping[str, Any]:
+    meta = getattr(chunk, "meta", None)
+    if meta is None:
+        return {}
+    if not isinstance(meta, Mapping):
+        raise TypeError("Chunk.meta must be a mapping/dict.")
+    return meta
+
+
+@dataclass(frozen=True, slots=True)
+class _Entry:
+    chunk: Any
+    vector: Tuple[float, ...]
+
+
+class InMemoryCosineVectorIndex(VectorIndex):
+    """
+    Naive in-memory cosine similarity index (v1).
+
+    - Stores vectors by chunk_id.
+    - Deterministic sorting: score desc, then chunk_id asc.
+    - Filters applied during scoring pass (v1 simplest + testable).
+    """
+
+    def __init__(self) -> None:
+        self._by_id: Dict[str, _Entry] = {}
+
+    def upsert(
+        self,
+        *,
+        chunks: Iterable[object],
+        vectors: Iterable[Sequence[float]],
+    ) -> None:
+        for ch, vec in zip(chunks, vectors):
+            cid = _chunk_id(ch)
+            vt = _as_tuple(vec)
+            self._by_id[cid] = _Entry(chunk=ch, vector=vt)
+
+    def search(
+        self,
+        *,
+        vector: Sequence[float],
+        k: int,
+        filters: RetrievalFilter | None = None,
+    ) -> Sequence[RetrievedChunk]:
+        if k <= 0:
+            raise ValueError("k must be a positive integer.")
+
+        qv = _as_tuple(vector)
+
+        scored: List[RetrievedChunk] = []
+        for cid, entry in self._by_id.items():
+            meta = _chunk_meta(entry.chunk)
+            if filters is not None and not filters.matches_meta(meta):
+                continue
+
+            score = cosine_similarity(qv, entry.vector)
+            scored.append(RetrievedChunk(chunk=entry.chunk, score=float(score)))
+
+        # Deterministic ranking: score desc, then chunk_id asc for ties
+        scored.sort(key=lambda r: (-r.score, r.chunk_id))
+
+        return scored[:k]

--- a/src/ragcopilot/retrieval/interfaces.py
+++ b/src/ragcopilot/retrieval/interfaces.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from abc import ABC, abstractmethod
 from typing import Iterable, Protocol, Sequence
 
-from .models import RetrievedChunk, RetrievalFilter, RetrievalQuery
+from .models import RetrievedChunk, RetrievalFilter, RetrievalQuery, RetrievalResult
 
 
 class EmbeddingProvider(Protocol):
@@ -54,8 +54,5 @@ class Retriever(ABC):
     """
 
     @abstractmethod
-    def retrieve(
-        self,
-        query: RetrievalQuery,
-    ) -> Sequence[RetrievedChunk]:
+    def retrieve(self, query: RetrievalQuery) -> RetrievalResult:
         raise NotImplementedError

--- a/src/ragcopilot/retrieval/interfaces.py
+++ b/src/ragcopilot/retrieval/interfaces.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from typing import Iterable, Protocol, Sequence
+
+from .models import RetrievedChunk, RetrievalFilter, RetrievalQuery
+
+
+class EmbeddingProvider(Protocol):
+    """
+    Produces vector embeddings for text.
+
+    Interface only — implementation lives elsewhere.
+    """
+
+    def embed(self, text: str) -> Sequence[float]:
+        ...
+
+
+class VectorIndex(ABC):
+    """
+    Abstract vector index for similarity search.
+    """
+
+    @abstractmethod
+    def upsert(
+        self,
+        *,
+        chunks: Iterable[object],
+        vectors: Iterable[Sequence[float]],
+    ) -> None:
+        """
+        Insert or update chunks with their vectors.
+        """
+        raise NotImplementedError
+
+    @abstractmethod
+    def search(
+        self,
+        *,
+        vector: Sequence[float],
+        k: int,
+        filters: RetrievalFilter | None = None,
+    ) -> Sequence[RetrievedChunk]:
+        """
+        Return top-k similar chunks for the given vector.
+        """
+        raise NotImplementedError
+
+
+class Retriever(ABC):
+    """
+    High-level retrieval interface.
+    """
+
+    @abstractmethod
+    def retrieve(
+        self,
+        query: RetrievalQuery,
+    ) -> Sequence[RetrievedChunk]:
+        raise NotImplementedError

--- a/src/ragcopilot/retrieval/models.py
+++ b/src/ragcopilot/retrieval/models.py
@@ -1,0 +1,116 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Iterable, Mapping, Optional, Sequence, Tuple
+
+
+Chunk = Any  # v1: keep models decoupled from the concrete chunk implementation
+
+
+@dataclass(frozen=True, slots=True)
+class RetrievalFilter:
+    """
+    Basic filters supported in v1.
+
+    - doc_type: exact match on chunk meta field "doc_type"
+    - tags: requires all filter tags to be present in chunk meta field "tags"
+    """
+    doc_type: Optional[str] = None
+    tags: Tuple[str, ...] = ()
+
+    def summary(self) -> dict:
+        return {
+            "doc_type": self.doc_type,
+            "tags": list(self.tags),
+        }
+
+    @staticmethod
+    def _normalize_tags(tags: Iterable[str]) -> Tuple[str, ...]:
+        # Deterministic normalization: unique + sorted
+        cleaned = {t.strip() for t in tags if t and t.strip()}
+        return tuple(sorted(cleaned))
+
+    @classmethod
+    def from_values(
+        cls,
+        doc_type: Optional[str] = None,
+        tags: Optional[Iterable[str]] = None,
+    ) -> "RetrievalFilter":
+        norm_tags = cls._normalize_tags(tags or [])
+        return cls(doc_type=doc_type, tags=norm_tags)
+
+    def matches_meta(self, meta: Mapping[str, Any]) -> bool:
+        if self.doc_type is not None:
+            if meta.get("doc_type") != self.doc_type:
+                return False
+
+        if self.tags:
+            meta_tags = meta.get("tags") or []
+            if isinstance(meta_tags, str):
+                meta_tag_set = {meta_tags}
+            else:
+                meta_tag_set = {str(t) for t in meta_tags}
+
+            # v1 rule: chunk must contain ALL requested tags
+            for t in self.tags:
+                if t not in meta_tag_set:
+                    return False
+
+        return True
+
+
+@dataclass(frozen=True, slots=True)
+class RetrievalQuery:
+    text: str
+    k: int = 5
+    filters: Optional[RetrievalFilter] = None
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.text, str) or not self.text.strip():
+            raise ValueError("RetrievalQuery.text must be a non-empty string.")
+        if not isinstance(self.k, int) or self.k <= 0:
+            raise ValueError("RetrievalQuery.k must be a positive integer.")
+
+
+@dataclass(frozen=True, slots=True)
+class RetrievedChunk:
+    chunk: Chunk
+    score: float
+
+    @property
+    def chunk_id(self) -> str:
+        # We require chunks to expose chunk_id for deterministic tie-breaks.
+        cid = getattr(self.chunk, "chunk_id", None)
+        if cid is None:
+            raise AttributeError("Chunk object must have attribute 'chunk_id'.")
+        return str(cid)
+
+
+@dataclass(frozen=True, slots=True)
+class RetrievalTrace:
+    """
+    Captures how retrieval selected results.
+
+    selected: ordered list of (chunk_id, score) for returned chunks.
+    filters: normalized filter summary (if any).
+    """
+    selected: Tuple[Tuple[str, float], ...] = ()
+    filters: dict = field(default_factory=dict)
+
+    @classmethod
+    def from_results(
+        cls,
+        results: Sequence[RetrievedChunk],
+        filters: Optional[RetrievalFilter],
+    ) -> "RetrievalTrace":
+        selected = tuple((r.chunk_id, float(r.score)) for r in results)
+        return cls(
+            selected=selected,
+            filters=(filters.summary() if filters else {}),
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class RetrievalResult:
+    items: Tuple[RetrievedChunk, ...]
+    trace: RetrievalTrace

--- a/src/ragcopilot/retrieval/retrievers/__init__.py
+++ b/src/ragcopilot/retrieval/retrievers/__init__.py
@@ -1,0 +1,3 @@
+from .basic import BasicRetriever
+
+__all__ = ["BasicRetriever"]

--- a/src/ragcopilot/retrieval/retrievers/basic.py
+++ b/src/ragcopilot/retrieval/retrievers/basic.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+from ..interfaces import EmbeddingProvider, Retriever, VectorIndex
+from ..models import RetrievalQuery, RetrievalResult, RetrievalTrace
+
+
+class BasicRetriever(Retriever):
+    """
+    Baseline retriever (v1):
+    - Embed query text
+    - Vector search top-k
+    - Return RetrievalResult with trace
+    """
+
+    def __init__(self, *, index: VectorIndex, embedder: EmbeddingProvider) -> None:
+        self._index = index
+        self._embedder = embedder
+
+    def retrieve(self, query: RetrievalQuery) -> RetrievalResult:
+        qvec = self._embedder.embed(query.text)
+        items = tuple(
+            self._index.search(
+                vector=qvec,
+                k=query.k,
+                filters=query.filters,
+            )
+        )
+        trace = RetrievalTrace.from_results(items, query.filters)
+        return RetrievalResult(items=items, trace=trace)

--- a/tests/retrieval/test_models.py
+++ b/tests/retrieval/test_models.py
@@ -1,0 +1,75 @@
+import pytest
+from dataclasses import dataclass
+
+from ragcopilot.retrieval.models import (
+    RetrievalFilter,
+    RetrievalQuery,
+    RetrievedChunk,
+    RetrievalTrace,
+    RetrievalResult,
+)
+
+
+@dataclass(frozen=True)
+class StubChunk:
+    chunk_id: str
+    meta: dict
+
+
+def test_query_validation() -> None:
+    with pytest.raises(ValueError):
+        RetrievalQuery(text="   ", k=5)
+    with pytest.raises(ValueError):
+        RetrievalQuery(text="hello", k=0)
+    q = RetrievalQuery(text="hello", k=3)
+    assert q.k == 3
+
+
+def test_filter_normalization_is_deterministic() -> None:
+    f = RetrievalFilter.from_values(doc_type="pdf", tags=[" b ", "a", "a", "", "  "])
+    assert f.doc_type == "pdf"
+    assert f.tags == ("a", "b")
+    assert f.summary() == {"doc_type": "pdf", "tags": ["a", "b"]}
+
+
+def test_filter_matches_doc_type() -> None:
+    f = RetrievalFilter.from_values(doc_type="md")
+    assert f.matches_meta({"doc_type": "md"}) is True
+    assert f.matches_meta({"doc_type": "pdf"}) is False
+    assert f.matches_meta({}) is False
+
+
+def test_filter_matches_tags_all_required() -> None:
+    f = RetrievalFilter.from_values(tags=["a", "b"])
+    assert f.matches_meta({"tags": ["a", "b", "c"]}) is True
+    assert f.matches_meta({"tags": ["a"]}) is False
+    assert f.matches_meta({"tags": "a"}) is False  # string treated as single tag
+
+
+def test_retrieved_chunk_exposes_chunk_id() -> None:
+    c = StubChunk(chunk_id="c1", meta={})
+    rc = RetrievedChunk(chunk=c, score=0.5)
+    assert rc.chunk_id == "c1"
+
+
+def test_trace_from_results_contains_expected_pairs() -> None:
+    c1 = StubChunk(chunk_id="c1", meta={})
+    c2 = StubChunk(chunk_id="c2", meta={})
+    r1 = RetrievedChunk(chunk=c1, score=0.9)
+    r2 = RetrievedChunk(chunk=c2, score=0.8)
+
+    filt = RetrievalFilter.from_values(doc_type="md", tags=["x"])
+    trace = RetrievalTrace.from_results([r1, r2], filt)
+
+    assert trace.selected == (("c1", 0.9), ("c2", 0.8))
+    assert trace.filters == {"doc_type": "md", "tags": ["x"]}
+
+
+def test_retrieval_result_is_immutable_tuple() -> None:
+    c = StubChunk(chunk_id="c1", meta={})
+    item = RetrievedChunk(chunk=c, score=1.0)
+    trace = RetrievalTrace.from_results([item], None)
+
+    res = RetrievalResult(items=(item,), trace=trace)
+    assert isinstance(res.items, tuple)
+    assert res.items[0].chunk_id == "c1"

--- a/tests/retrieval/test_retrieval_v1.py
+++ b/tests/retrieval/test_retrieval_v1.py
@@ -1,0 +1,100 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Sequence
+
+from ragcopilot.retrieval.index.in_memory import InMemoryCosineVectorIndex
+from ragcopilot.retrieval.models import RetrievalFilter, RetrievalQuery
+from ragcopilot.retrieval.retrievers.basic import BasicRetriever
+
+
+@dataclass(frozen=True)
+class StubChunk:
+    chunk_id: str
+    meta: dict
+
+
+class StubEmbedder:
+    def __init__(self, mapping: dict[str, Sequence[float]]) -> None:
+        self._mapping = mapping
+
+    def embed(self, text: str) -> Sequence[float]:
+        return self._mapping[text]
+
+
+def test_returns_exactly_top_k() -> None:
+    idx = InMemoryCosineVectorIndex()
+    chunks = [
+        StubChunk("c1", {"doc_type": "md", "tags": ["a"]}),
+        StubChunk("c2", {"doc_type": "md", "tags": ["a", "b"]}),
+        StubChunk("c3", {"doc_type": "pdf", "tags": ["b"]}),
+    ]
+    # Query vector = [1, 0]
+    vectors = [
+        [1, 0],   # c1 sim 1.0
+        [0.8, 0], # c2 sim 1.0 (same direction)
+        [0, 1],   # c3 sim 0.0
+    ]
+    idx.upsert(chunks=chunks, vectors=vectors)
+
+    retriever = BasicRetriever(index=idx, embedder=StubEmbedder({"q": [1, 0]}))
+    res = retriever.retrieve(RetrievalQuery(text="q", k=2))
+
+    assert len(res.items) == 2
+    assert [it.chunk.chunk_id for it in res.items] == ["c1", "c2"]
+
+
+def test_tie_break_determinism_chunk_id_asc() -> None:
+    idx = InMemoryCosineVectorIndex()
+    # Both vectors are identical direction => same cosine score
+    c_a = StubChunk("a10", {"doc_type": "md", "tags": []})
+    c_b = StubChunk("a02", {"doc_type": "md", "tags": []})
+    idx.upsert(chunks=[c_a, c_b], vectors=[[1, 0], [1, 0]])
+
+    retriever = BasicRetriever(index=idx, embedder=StubEmbedder({"q": [1, 0]}))
+    res = retriever.retrieve(RetrievalQuery(text="q", k=2))
+
+    # same score, order by chunk_id asc => a02 then a10
+    assert [it.chunk.chunk_id for it in res.items] == ["a02", "a10"]
+
+
+def test_filter_doc_type() -> None:
+    idx = InMemoryCosineVectorIndex()
+    c1 = StubChunk("c1", {"doc_type": "md", "tags": ["a"]})
+    c2 = StubChunk("c2", {"doc_type": "pdf", "tags": ["a"]})
+    idx.upsert(chunks=[c1, c2], vectors=[[1, 0], [1, 0]])
+
+    retriever = BasicRetriever(index=idx, embedder=StubEmbedder({"q": [1, 0]}))
+    f = RetrievalFilter.from_values(doc_type="md")
+    res = retriever.retrieve(RetrievalQuery(text="q", k=5, filters=f))
+
+    assert [it.chunk.chunk_id for it in res.items] == ["c1"]
+
+
+def test_filter_tags_all_required() -> None:
+    idx = InMemoryCosineVectorIndex()
+    c1 = StubChunk("c1", {"doc_type": "md", "tags": ["a"]})
+    c2 = StubChunk("c2", {"doc_type": "md", "tags": ["a", "b"]})
+    c3 = StubChunk("c3", {"doc_type": "md", "tags": ["b"]})
+    idx.upsert(chunks=[c1, c2, c3], vectors=[[1, 0], [1, 0], [1, 0]])
+
+    retriever = BasicRetriever(index=idx, embedder=StubEmbedder({"q": [1, 0]}))
+    f = RetrievalFilter.from_values(tags=["a", "b"])
+    res = retriever.retrieve(RetrievalQuery(text="q", k=10, filters=f))
+
+    assert [it.chunk.chunk_id for it in res.items] == ["c2"]
+
+
+def test_trace_contains_expected_scores_and_ids() -> None:
+    idx = InMemoryCosineVectorIndex()
+    c1 = StubChunk("c1", {"doc_type": "md", "tags": ["x"]})
+    c2 = StubChunk("c2", {"doc_type": "md", "tags": ["x"]})
+    idx.upsert(chunks=[c1, c2], vectors=[[1, 0], [0, 1]])
+
+    retriever = BasicRetriever(index=idx, embedder=StubEmbedder({"q": [1, 0]}))
+    f = RetrievalFilter.from_values(doc_type="md", tags=["x"])
+    res = retriever.retrieve(RetrievalQuery(text="q", k=2, filters=f))
+
+    assert [it.chunk.chunk_id for it in res.items] == ["c1", "c2"]
+    assert res.trace.selected[0][0] == "c1"
+    assert res.trace.filters == {"doc_type": "md", "tags": ["x"]}


### PR DESCRIPTION
## Summary
Implements Retrieval v1 for the RAG Copilot.

This PR adds a deterministic, local-first retrieval pipeline with:
- In-memory cosine similarity vector index
- Top-k ranking with deterministic tie-breaking
- Basic filters (doc_type, tags)
- Retrieval trace (selected chunk_ids, scores, applied filters)

## Scope
- Defines retrieval data models and clean architecture interfaces
- Implements `InMemoryCosineVectorIndex`
- Implements `BasicRetriever`
- Adds comprehensive pytest coverage for retrieval behavior

## Acceptance Criteria
- [x] Vector similarity search returns top-k chunks
- [x] Basic filters supported (doc_type, tags)
- [x] Retrieval trace captured (scores + selected chunks)
- [x] Deterministic and fully testable

Closes #7